### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const assert = require('assert')
 const crypto = require("crypto");
 const x509 = require('@peculiar/x509');
 class Payment {
-    constructor({appid, mchid, private_key, serial_no,apiv3_private_key,notify_url} = {}) {
+    constructor({appid, mchid, private_key, serial_no,apiv3_private_key,notify_url,oversea = false} = {}) {
         assert(appid, 'appid is required')
         assert(mchid, 'mchid is required')
         assert(private_key, 'private_key is required')
@@ -22,30 +22,30 @@ class Payment {
         this.urls = {
             jsapi:() => {
                 return {
-                    url:'https://api.mch.weixin.qq.com/v3/pay/transactions/jsapi',
+                    url: !oversea ? 'https://api.mch.weixin.qq.com/v3/pay/transactions/jsapi' : 'https://api.mch.weixin.qq.com/hk/v3/transactions/jsapi',
                     method:'POST',
-                    pathname:'/v3/pay/transactions/jsapi',
+                    pathname: !oversea ? '/v3/pay/transactions/jsapi' : '/hk/v3/transactions/jsapi',
                 }
             },
             app:() => {
                 return {
-                    url:'https://api.mch.weixin.qq.com/v3/pay/transactions/app',
+                    url: !oversea ? 'https://api.mch.weixin.qq.com/v3/pay/transactions/app' : 'https://api.mch.weixin.qq.com/hk/v3/transactions/app',
                     method:'POST',
-                    pathname:'/v3/pay/transactions/app',
+                    pathname: !oversea ? '/v3/pay/transactions/app' : '/hk/v3/transactions/app',
                 }
             },
             h5:() => {
                 return {
-                    url:'https://api.mch.weixin.qq.com/v3/pay/transactions/h5',
+                    url: !oversea ? 'https://api.mch.weixin.qq.com/v3/pay/transactions/h5' : 'https://api.mch.weixin.qq.com/hk/v3/transactions/h5',
                     method:'POST',
-                    pathname:'/v3/pay/transactions/h5',
+                    pathname:!oversea ? '/v3/pay/transactions/h5' : '/hk/v3/transactions/h5',
                 }
             },
             native:() => {
                 return {
-                    url:'https://api.mch.weixin.qq.com/v3/pay/transactions/native',
+                    url:!oversea ? 'https://api.mch.weixin.qq.com/v3/pay/transactions/native' : 'https://api.mch.weixin.qq.com/hk/v3/transactions/native',
                     method:'POST',
-                    pathname:'/v3/pay/transactions/native',
+                    pathname:!oversea ? '/v3/pay/transactions/native' : '/hk/v3/transactions/native',
                 }
             },
             getTransactionsById:({pathParams}) => {


### PR DESCRIPTION
考虑微信支付v3接口支持海外版
微信支付v3 接口 应该支持海外版，需添加海外版接口url
微信支付v3海外版接口官方地址：https://pay.weixin.qq.com/wiki/doc/api/wxpay/ch/pages/In-AppPay_fw.shtml